### PR TITLE
Update some missing cases for button border-radius

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -124,6 +124,10 @@ $combo-box-text: $basic-button-text !default;
   color: $basic-button-text;
 }
 
+.btn-hover, .btn-active, .btn-large, .btn-small {
+    border-radius: $global-button-border-radius;
+}
+
 // Various edge cases
 
 .select-kit.dropdown-select-box.toolbar-popup-menu-options .select-kit-row,

--- a/common/common.scss
+++ b/common/common.scss
@@ -124,7 +124,7 @@ $combo-box-text: $basic-button-text !default;
   color: $basic-button-text;
 }
 
-.btn-hover, .btn-active, .btn-large, .btn-small {
+.btn-hover, .btn-active, .btn-large, .btn-small, .btn-text {
     border-radius: $global-button-border-radius;
 }
 


### PR DESCRIPTION
- btn-small, btn-large, btn-hover and btn-active were missing the global button border radius

Please feel free to let me know changes needed, if there is a more appropriate way to target those buttons. I'm not that practised with CSS yet — was just trying to clean up some of the cases for my Discourse forum.

Before:
<img width="573" alt="image" src="https://user-images.githubusercontent.com/22441348/184524214-aaaec3f1-cdbe-4695-97ea-2ad2ec0ffa88.png">

After:
<img width="567" alt="image" src="https://user-images.githubusercontent.com/22441348/184524196-8679c4a4-5c65-479b-bb90-c0b0595dd304.png">

Also added `btn-text` to target this case:
<img width="403" alt="image" src="https://user-images.githubusercontent.com/22441348/190833073-b9bbf8a1-3830-4210-ae4a-6bc894b64775.png">
