### PR TITLE
Fix border-radius edge case for Like button

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -183,7 +183,7 @@ label.btn i {
 
 // Edge case for like button (double button)
 
-.double-button > .like-count {
+.double-button > .btn-text {
     border-top-right-radius: 0px !important;
     border-bottom-right-radius: 0px !important;
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -188,7 +188,7 @@ label.btn i {
     border-bottom-right-radius: 0px !important;
 }
 
-.double-button > .like-count + .btn-icon {
+.double-button > .btn-text + .btn-icon {
     border-top-left-radius: 0px !important;
     border-bottom-left-radius: 0px !important;
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -181,6 +181,18 @@ label.btn i {
   }
 }
 
+// Edge case for like button (double button)
+
+.double-button .btn-text {
+    border-top-right-radius: 0px !important;
+    border-bottom-right-radius: 0px !important;
+}
+
+.double-button .btn-icon {
+    border-top-left-radius: 0px !important;
+    border-bottom-left-radius: 0px !important;
+}
+
 // Header nav
 
 .d-header-icons {

--- a/common/common.scss
+++ b/common/common.scss
@@ -183,12 +183,12 @@ label.btn i {
 
 // Edge case for like button (double button)
 
-.double-button .btn-text {
+.double-button > .like-count {
     border-top-right-radius: 0px !important;
     border-bottom-right-radius: 0px !important;
 }
 
-.double-button .btn-icon {
+.double-button > .like-count + .btn-icon {
     border-top-left-radius: 0px !important;
     border-bottom-left-radius: 0px !important;
 }


### PR DESCRIPTION
On other people's posts, the like button is made of two buttons. The border radius would be added for both buttons, whereas we just want it on the outer sides of the two buttons.

Before:

<img width="283" alt="image" src="https://user-images.githubusercontent.com/22441348/194202126-473d1675-c2b3-44da-81e8-dfe281aba6b9.png">


After:

<img width="304" alt="image" src="https://user-images.githubusercontent.com/22441348/194202038-111711f0-de0b-43fa-b98d-80deee635e4e.png">

@awesomerobot 